### PR TITLE
Always show scheduling information

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 <script>
 
 function update_room (room, status) {
-  var show = '';
+  var show = $('#' + room + "-empty").text();
   if (status == 'UNOCCUPIED') show = 'Yes!';
   else if (status == 'OCCUPIED' || status == 'UNSURE') show = 'Taken, sorry.';
 
@@ -224,6 +224,9 @@ $.ajax({
         reservations[room] = [];
       }
       reservations[room].push([start_ts, finish_ts, purpose]);
+
+      // Call w/out status so that conf field fill in
+      update_room(room);
     });
 
     //console.log(reservations);


### PR DESCRIPTION
Previously this would only update when occupancy data came in, but it's useful
as a dashboard of reservations even if no occupancy data comes in.

Tested locally. Issued as PR so @bradjc will update server.
